### PR TITLE
Added missing include

### DIFF
--- a/ObjCreator.h
+++ b/ObjCreator.h
@@ -15,6 +15,7 @@
 #include"VertexElement.h"
 #include"VertexNormalElement.h"
 #include"VertexTextureElement.h"
+#include "VertexStructure.h"
 
 namespace ObjMaster {
 	/**


### PR DESCRIPTION
Added VertexStructure.h include to ObjCreator.h to make it compile with dxf_obj.